### PR TITLE
clears local storage/removes last item from cart entirely

### DIFF
--- a/src/context/CartProvider.jsx
+++ b/src/context/CartProvider.jsx
@@ -55,13 +55,27 @@ export const CartProvider = ({ children }) => {
     setCart((prevCart) => {
       const existingItem = prevCart.find((cartItem) => cartItem.id === id);
       if (existingItem.quantity > 1) {
-        return prevCart?.map((cartItem) =>
+        const updatedCart = prevCart.map((cartItem) =>
           cartItem.id === id
             ? { ...cartItem, quantity: cartItem.quantity - 1 }
             : cartItem
         );
+        // Save the updated cart to localStorage
+        localStorage.setItem("cart", JSON.stringify(updatedCart));
+        return updatedCart;
       }
-      return prevCart.filter((cartItem) => cartItem.id !== id);
+
+      // Remove the item from the cart entirely
+      const updatedCart = prevCart.filter((cartItem) => cartItem.id !== id);
+
+      // Clear localStorage if the cart is empty
+      if (updatedCart.length === 0) {
+        localStorage.removeItem("cart");
+      } else {
+        // Save the updated cart to localStorage if it's not empty
+        localStorage.setItem("cart", JSON.stringify(updatedCart));
+      }
+      return updatedCart;
     });
   };
 


### PR DESCRIPTION
## Prevent last cart item from persisting in localStorage

### Description:

- Fixed issue where removing the last item in the cart didn't clear the localStorage and persisted the empty cart.

- Now, if the cart becomes empty after removing the last item, localStorage is cleared.

### Changes:

- Updated removeFromCart function to clear localStorage when the cart is empty.